### PR TITLE
bugfix: Change the plugin source name to its valid form.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ packer {
   required_plugins {
    xenserver= {
       version = ">= v0.6.0"
-      source = "github.com/vatesfr/packer-plugin-xenserver"
+      source = "github.com/vatesfr/xenserver"
     }
   }
 }

--- a/examples/centos/centos8-local.pkr.hcl
+++ b/examples/centos/centos8-local.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
    xenserver= {
       version = ">= v0.6.0"
-      source = "github.com/vatesfr/packer-plugin-xenserver"
+      source = "github.com/vatesfr/xenserver"
     }
   }
 }

--- a/examples/centos/centos8-netinstall.pkr.hcl
+++ b/examples/centos/centos8-netinstall.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
    xenserver= {
       version = ">= v0.6.0"
-      source = "github.com/vatesfr/packer-plugin-xenserver"
+      source = "github.com/vatesfr/xenserver"
     }
   }
 }

--- a/examples/ubuntu/ubuntu-2004.pkr.hcl
+++ b/examples/ubuntu/ubuntu-2004.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
    xenserver= {
       version = ">= v0.5.2"
-      source = "github.com/vatesfr/packer-plugin-xenserver"
+      source = "github.com/vatesfr/xenserver"
     }
   }
 }

--- a/examples/ubuntu/ubuntu-2404.pkr.hcl
+++ b/examples/ubuntu/ubuntu-2404.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
    xenserver= {
       version = ">= v0.7.4"
-      source = "github.com/vatesfr/packer-plugin-xenserver"
+      source = "github.com/vatesfr/xenserver"
     }
   }
 }


### PR DESCRIPTION
`packer init` fails with the new plugin source name "github.com/vatesfr/packer-plugin-xenserver", at least on Packer v1.13.1. This is the error message that gets returned:

```
Error: Failed to parse source

  on ubuntu/xo-ubuntu.pkr.hcl line 3, in packer:
   3:     xenserver = {
   4:       version = "~> v0.8.1"
   5:       source  = "github.com/vatesfr/packer-plugin-xenserver"
   6:     }

Plugin source has a type with the prefix "packer-plugin-", which isn't valid.
Although that prefix is often used in the names of version control repositories
for Packer plugins, plugin source strings should not include it.

Did you mean "xenserver"?
```